### PR TITLE
refactor: move from io/ioutil to io and os packages (#1633)

### DIFF
--- a/api/metadata/server.go
+++ b/api/metadata/server.go
@@ -5,7 +5,7 @@ import (
 	"compress/gzip"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"sync"
 
 	"google.golang.org/grpc"
@@ -180,7 +180,7 @@ func decompress(b []byte) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("bad gzipped descriptor: %v", err)
 	}
-	out, err := ioutil.ReadAll(r)
+	out, err := io.ReadAll(r)
 	if err != nil {
 		return nil, fmt.Errorf("bad gzipped descriptor: %v", err)
 	}

--- a/cmd/kratos/internal/base/mod.go
+++ b/cmd/kratos/internal/base/mod.go
@@ -3,7 +3,7 @@ package base
 import (
 	"bufio"
 	"bytes"
-	"io/ioutil"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -13,7 +13,7 @@ import (
 
 // ModulePath returns go module path.
 func ModulePath(filename string) (string, error) {
-	modBytes, err := ioutil.ReadFile(filename)
+	modBytes, err := os.ReadFile(filename)
 	if err != nil {
 		return "", err
 	}

--- a/cmd/kratos/internal/base/path.go
+++ b/cmd/kratos/internal/base/path.go
@@ -3,7 +3,6 @@ package base
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path"
@@ -43,7 +42,7 @@ func copyFile(src, dst string, replaces []string) error {
 	if err != nil {
 		return err
 	}
-	buf, err := ioutil.ReadFile(src)
+	buf, err := os.ReadFile(src)
 	if err != nil {
 		return err
 	}
@@ -55,12 +54,12 @@ func copyFile(src, dst string, replaces []string) error {
 		}
 		buf = bytes.ReplaceAll(buf, []byte(old), []byte(next))
 	}
-	return ioutil.WriteFile(dst, buf, srcinfo.Mode())
+	return os.WriteFile(dst, buf, srcinfo.Mode())
 }
 
 func copyDir(src, dst string, replaces, ignores []string) error {
 	var err error
-	var fds []os.FileInfo
+	var fds []os.DirEntry
 	var srcinfo os.FileInfo
 
 	if srcinfo, err = os.Stat(src); err != nil {
@@ -71,7 +70,7 @@ func copyDir(src, dst string, replaces, ignores []string) error {
 		return err
 	}
 
-	if fds, err = ioutil.ReadDir(src); err != nil {
+	if fds, err = os.ReadDir(src); err != nil {
 		return err
 	}
 	for _, fd := range fds {

--- a/cmd/kratos/internal/change/get.go
+++ b/cmd/kratos/internal/change/get.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"regexp"
@@ -104,7 +103,7 @@ func requestGithubAPI(url string, method string, body io.Reader, token string) (
 		fatal(err)
 	}
 	defer resp.Body.Close()
-	resBody, err := ioutil.ReadAll(resp.Body)
+	resBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		fatal(err)
 	}

--- a/cmd/kratos/internal/proto/add/add.go
+++ b/cmd/kratos/internal/proto/add/add.go
@@ -2,7 +2,7 @@ package add
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -44,9 +44,9 @@ func run(cmd *cobra.Command, args []string) {
 }
 
 func modName() string {
-	modBytes, err := ioutil.ReadFile("go.mod")
+	modBytes, err := os.ReadFile("go.mod")
 	if err != nil {
-		if modBytes, err = ioutil.ReadFile("../go.mod"); err != nil {
+		if modBytes, err = os.ReadFile("../go.mod"); err != nil {
 			return ""
 		}
 	}

--- a/cmd/kratos/internal/proto/add/proto.go
+++ b/cmd/kratos/internal/proto/add/proto.go
@@ -2,7 +2,6 @@ package add
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 )
@@ -37,5 +36,5 @@ func (p *Proto) Generate() error {
 	if _, err := os.Stat(name); !os.IsNotExist(err) {
 		return fmt.Errorf("%s already exists", p.Name)
 	}
-	return ioutil.WriteFile(name, body, 0o644)
+	return os.WriteFile(name, body, 0o644)
 }

--- a/cmd/kratos/internal/proto/client/client.go
+++ b/cmd/kratos/internal/proto/client/client.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -98,7 +97,7 @@ func generate(proto string, args []string) error {
 		"--go-errors_out=paths=source_relative:.",
 	}
 	input = append(input, inputExt...)
-	protoBytes, err := ioutil.ReadFile(proto)
+	protoBytes, err := os.ReadFile(proto)
 	if err == nil && len(protoBytes) > 0 {
 		if ok, _ := regexp.Match(`\n[^/]*(import)\s+"validate/validate.proto"`, protoBytes); ok {
 			input = append(input, "--validate_out=lang=go,paths=source_relative:.")

--- a/cmd/kratos/internal/proto/server/server.go
+++ b/cmd/kratos/internal/proto/server/server.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path"
@@ -83,7 +82,7 @@ func run(cmd *cobra.Command, args []string) {
 		if err != nil {
 			log.Fatal(err)
 		}
-		if err := ioutil.WriteFile(to, b, 0o644); err != nil {
+		if err := os.WriteFile(to, b, 0o644); err != nil {
 			log.Fatal(err)
 		}
 		fmt.Println(to)

--- a/cmd/kratos/internal/run/run.go
+++ b/cmd/kratos/internal/run/run.go
@@ -2,7 +2,6 @@ package run
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -79,7 +78,7 @@ func findCMD(base string) (map[string]string, error) {
 		err := filepath.Walk(dir, func(walkPath string, info os.FileInfo, err error) error {
 			// multi level directory is not allowed under the cmdPath directory, so it is judged that the path ends with cmdPath.
 			if strings.HasSuffix(walkPath, "cmd") {
-				paths, err := ioutil.ReadDir(walkPath)
+				paths, err := os.ReadDir(walkPath)
 				if err != nil {
 					return err
 				}

--- a/config/env/env_test.go
+++ b/config/env/env_test.go
@@ -1,7 +1,6 @@
 package env
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -39,7 +38,7 @@ func TestEnvWithPrefix(t *testing.T) {
 	if err := os.MkdirAll(path, 0o700); err != nil {
 		t.Error(err)
 	}
-	if err := ioutil.WriteFile(filename, data, 0o666); err != nil {
+	if err := os.WriteFile(filename, data, 0o666); err != nil {
 		t.Error(err)
 	}
 
@@ -149,7 +148,7 @@ func TestEnvWithoutPrefix(t *testing.T) {
 	if err := os.MkdirAll(path, 0o700); err != nil {
 		t.Error(err)
 	}
-	if err := ioutil.WriteFile(filename, data, 0o666); err != nil {
+	if err := os.WriteFile(filename, data, 0o666); err != nil {
 		t.Error(err)
 	}
 

--- a/config/file/file.go
+++ b/config/file/file.go
@@ -1,7 +1,7 @@
 package file
 
 import (
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -26,7 +26,7 @@ func (f *file) loadFile(path string) (*config.KeyValue, error) {
 		return nil, err
 	}
 	defer file.Close()
-	data, err := ioutil.ReadAll(file)
+	data, err := io.ReadAll(file)
 	if err != nil {
 		return nil, err
 	}
@@ -42,7 +42,7 @@ func (f *file) loadFile(path string) (*config.KeyValue, error) {
 }
 
 func (f *file) loadDir(path string) (kvs []*config.KeyValue, err error) {
-	files, err := ioutil.ReadDir(f.path)
+	files, err := os.ReadDir(f.path)
 	if err != nil {
 		return nil, err
 	}

--- a/config/file/file_test.go
+++ b/config/file/file_test.go
@@ -2,7 +2,6 @@ package file
 
 import (
 	"errors"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sync"
@@ -93,7 +92,7 @@ func TestFile(t *testing.T) {
 	if err := os.MkdirAll(path, 0o700); err != nil {
 		t.Error(err)
 	}
-	if err := ioutil.WriteFile(file, data, 0o666); err != nil {
+	if err := os.WriteFile(file, data, 0o666); err != nil {
 		t.Error(err)
 	}
 	testSource(t, file, data)
@@ -181,7 +180,7 @@ func testSource(t *testing.T, path string, data []byte) {
 func TestConfig(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "test_config.json")
 	defer os.Remove(path)
-	if err := ioutil.WriteFile(path, []byte(_testJSON), 0o666); err != nil {
+	if err := os.WriteFile(path, []byte(_testJSON), 0o666); err != nil {
 		t.Error(err)
 	}
 	c := config.New(config.WithSource(
@@ -293,7 +292,7 @@ func testScan(t *testing.T, c config.Config) {
 func TestMergeDataRace(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "test_config.json")
 	defer os.Remove(path)
-	if err := ioutil.WriteFile(path, []byte(_testJSON), 0o666); err != nil {
+	if err := os.WriteFile(path, []byte(_testJSON), 0o666); err != nil {
 		t.Error(err)
 	}
 	c := config.New(config.WithSource(

--- a/contrib/log/fluent/fluent_test.go
+++ b/contrib/log/fluent/fluent_test.go
@@ -1,7 +1,7 @@
 package fluent
 
 import (
-	"io/ioutil"
+	"io"
 	"net"
 	"os"
 	"testing"
@@ -19,7 +19,7 @@ func TestMain(m *testing.M) {
 					return
 				}
 				defer conn.Close()
-				if _, err = ioutil.ReadAll(conn); err != nil {
+				if _, err = io.ReadAll(conn); err != nil {
 					continue
 				}
 			}

--- a/contrib/registry/kubernetes/registry.go
+++ b/contrib/registry/kubernetes/registry.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"strconv"
@@ -249,7 +248,7 @@ var currentNamespace = LoadNamespace()
 
 // LoadNamespace is used to get the current namespace from the file
 func LoadNamespace() string {
-	data, err := ioutil.ReadFile(ServiceAccountNamespacePath)
+	data, err := os.ReadFile(ServiceAccountNamespacePath)
 	if err != nil {
 		return ""
 	}

--- a/examples/tls/client/main.go
+++ b/examples/tls/client/main.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
-	"io/ioutil"
 	"log"
+	"os"
 
 	pb "github.com/go-kratos/kratos/examples/helloworld/helloworld"
 	"github.com/go-kratos/kratos/v2/transport/grpc"
@@ -14,7 +14,7 @@ import (
 
 func main() {
 	// Load CA certificate pem file.
-	b, err := ioutil.ReadFile("../cert/ca.crt")
+	b, err := os.ReadFile("../cert/ca.crt")
 	if err != nil {
 		panic(err)
 	}

--- a/examples/tls/tls_test.go
+++ b/examples/tls/tls_test.go
@@ -5,7 +5,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 	"time"
 
@@ -100,7 +100,7 @@ func TestETCD(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	b, err := ioutil.ReadFile("./cert/server.crt")
+	b, err := os.ReadFile("./cert/server.crt")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/log/filter_test.go
+++ b/log/filter_test.go
@@ -1,7 +1,7 @@
 package log
 
 import (
-	"io/ioutil"
+	"io"
 	"testing"
 )
 
@@ -58,21 +58,21 @@ func TestFilterFunc(t *testing.T) {
 }
 
 func BenchmarkFilterKey(b *testing.B) {
-	log := NewHelper(NewFilter(NewStdLogger(ioutil.Discard), FilterKey("password")))
+	log := NewHelper(NewFilter(NewStdLogger(io.Discard), FilterKey("password")))
 	for i := 0; i < b.N; i++ {
 		log.Infow("password", "123456")
 	}
 }
 
 func BenchmarkFilterValue(b *testing.B) {
-	log := NewHelper(NewFilter(NewStdLogger(ioutil.Discard), FilterValue("password")))
+	log := NewHelper(NewFilter(NewStdLogger(io.Discard), FilterValue("password")))
 	for i := 0; i < b.N; i++ {
 		log.Infow("password")
 	}
 }
 
 func BenchmarkFilterFunc(b *testing.B) {
-	log := NewHelper(NewFilter(NewStdLogger(ioutil.Discard), FilterFunc(testFilterFunc)))
+	log := NewHelper(NewFilter(NewStdLogger(io.Discard), FilterFunc(testFilterFunc)))
 	for i := 0; i < b.N; i++ {
 		log.Info("password", "123456")
 	}

--- a/log/helper_test.go
+++ b/log/helper_test.go
@@ -2,7 +2,7 @@ package log
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"os"
 	"testing"
 )
@@ -40,21 +40,21 @@ func TestHelperLevel(t *testing.T) {
 }
 
 func BenchmarkHelperPrint(b *testing.B) {
-	log := NewHelper(NewStdLogger(ioutil.Discard))
+	log := NewHelper(NewStdLogger(io.Discard))
 	for i := 0; i < b.N; i++ {
 		log.Debug("test")
 	}
 }
 
 func BenchmarkHelperPrintf(b *testing.B) {
-	log := NewHelper(NewStdLogger(ioutil.Discard))
+	log := NewHelper(NewStdLogger(io.Discard))
 	for i := 0; i < b.N; i++ {
 		log.Debugf("%s", "test")
 	}
 }
 
 func BenchmarkHelperPrintw(b *testing.B) {
-	log := NewHelper(NewStdLogger(ioutil.Discard))
+	log := NewHelper(NewStdLogger(io.Discard))
 	for i := 0; i < b.N; i++ {
 		log.Debugw("key", "value")
 	}

--- a/transport/http/client.go
+++ b/transport/http/client.go
@@ -6,7 +6,6 @@ import (
 	"crypto/tls"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"time"
 
@@ -322,7 +321,7 @@ func DefaultRequestEncoder(ctx context.Context, contentType string, in interface
 // DefaultResponseDecoder is an HTTP response decoder.
 func DefaultResponseDecoder(ctx context.Context, res *http.Response, v interface{}) error {
 	defer res.Body.Close()
-	data, err := ioutil.ReadAll(res.Body)
+	data, err := io.ReadAll(res.Body)
 	if err != nil {
 		return err
 	}
@@ -335,7 +334,7 @@ func DefaultErrorDecoder(ctx context.Context, res *http.Response) error {
 		return nil
 	}
 	defer res.Body.Close()
-	data, err := ioutil.ReadAll(res.Body)
+	data, err := io.ReadAll(res.Body)
 	if err == nil {
 		e := new(errors.Error)
 		if err = CodecForResponse(res).Unmarshal(data, e); err == nil {

--- a/transport/http/client_test.go
+++ b/transport/http/client_test.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	nethttp "net/http"
 	"testing"
 	"time"
@@ -135,7 +135,7 @@ func TestWithDiscovery(t *testing.T) {
 func TestDefaultRequestEncoder(t *testing.T) {
 	req1 := &nethttp.Request{
 		Header: make(nethttp.Header),
-		Body:   ioutil.NopCloser(bytes.NewBufferString("{\"a\":\"1\", \"b\": 2}")),
+		Body:   io.NopCloser(bytes.NewBufferString("{\"a\":\"1\", \"b\": 2}")),
 	}
 	req1.Header.Set("Content-Type", "application/xml")
 
@@ -158,7 +158,7 @@ func TestDefaultResponseDecoder(t *testing.T) {
 	resp1 := &nethttp.Response{
 		Header:     make(nethttp.Header),
 		StatusCode: 200,
-		Body:       ioutil.NopCloser(bytes.NewBufferString("{\"a\":\"1\", \"b\": 2}")),
+		Body:       io.NopCloser(bytes.NewBufferString("{\"a\":\"1\", \"b\": 2}")),
 	}
 	v1 := &struct {
 		A string `json:"a"`
@@ -172,7 +172,7 @@ func TestDefaultResponseDecoder(t *testing.T) {
 	resp2 := &nethttp.Response{
 		Header:     make(nethttp.Header),
 		StatusCode: 200,
-		Body:       ioutil.NopCloser(bytes.NewBufferString("{badjson}")),
+		Body:       io.NopCloser(bytes.NewBufferString("{badjson}")),
 	}
 	v2 := &struct {
 		A string `json:"a"`
@@ -191,14 +191,14 @@ func TestDefaultErrorDecoder(t *testing.T) {
 	resp1 := &nethttp.Response{
 		Header:     make(nethttp.Header),
 		StatusCode: 300,
-		Body:       ioutil.NopCloser(bytes.NewBufferString("{\"foo\":\"bar\"}")),
+		Body:       io.NopCloser(bytes.NewBufferString("{\"foo\":\"bar\"}")),
 	}
 	assert.Error(t, DefaultErrorDecoder(context.TODO(), resp1))
 
 	resp2 := &nethttp.Response{
 		Header:     make(nethttp.Header),
 		StatusCode: 500,
-		Body:       ioutil.NopCloser(bytes.NewBufferString("{\"code\":54321, \"message\": \"hi\", \"reason\": \"FOO\"}")),
+		Body:       io.NopCloser(bytes.NewBufferString("{\"code\":54321, \"message\": \"hi\", \"reason\": \"FOO\"}")),
 	}
 	err2 := DefaultErrorDecoder(context.TODO(), resp2)
 	assert.Error(t, err2)

--- a/transport/http/codec.go
+++ b/transport/http/codec.go
@@ -1,7 +1,7 @@
 package http
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/go-kratos/kratos/v2/encoding"
@@ -27,7 +27,7 @@ func DefaultRequestDecoder(r *http.Request, v interface{}) error {
 	if !ok {
 		return errors.BadRequest("CODEC", r.Header.Get("Content-Type"))
 	}
-	data, err := ioutil.ReadAll(r.Body)
+	data, err := io.ReadAll(r.Body)
 	if err != nil {
 		return errors.BadRequest("CODEC", err.Error())
 	}

--- a/transport/http/codec_test.go
+++ b/transport/http/codec_test.go
@@ -2,7 +2,7 @@ package http
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	nethttp "net/http"
 	"testing"
 
@@ -13,7 +13,7 @@ import (
 func TestDefaultRequestDecoder(t *testing.T) {
 	req1 := &nethttp.Request{
 		Header: make(nethttp.Header),
-		Body:   ioutil.NopCloser(bytes.NewBufferString("{\"a\":\"1\", \"b\": 2}")),
+		Body:   io.NopCloser(bytes.NewBufferString("{\"a\":\"1\", \"b\": 2}")),
 	}
 	req1.Header.Set("Content-Type", "application/json")
 
@@ -83,7 +83,7 @@ func TestDefaultResponseEncoderWithError(t *testing.T) {
 func TestCodecForRequest(t *testing.T) {
 	req1 := &nethttp.Request{
 		Header: make(nethttp.Header),
-		Body:   ioutil.NopCloser(bytes.NewBufferString("<xml></xml>")),
+		Body:   io.NopCloser(bytes.NewBufferString("<xml></xml>")),
 	}
 	req1.Header.Set("Content-Type", "application/xml")
 
@@ -93,7 +93,7 @@ func TestCodecForRequest(t *testing.T) {
 
 	req2 := &nethttp.Request{
 		Header: make(nethttp.Header),
-		Body:   ioutil.NopCloser(bytes.NewBufferString("{\"a\":\"1\", \"b\": 2}")),
+		Body:   io.NopCloser(bytes.NewBufferString("{\"a\":\"1\", \"b\": 2}")),
 	}
 	req2.Header.Set("Content-Type", "blablablabla")
 

--- a/transport/http/server_test.go
+++ b/transport/http/server_test.go
@@ -5,7 +5,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -113,7 +113,7 @@ func testClient(t *testing.T, srv *Server) {
 			_ = resp.Body.Close()
 			t.Fatalf("http status got %d", resp.StatusCode)
 		}
-		content, err := ioutil.ReadAll(resp.Body)
+		content, err := io.ReadAll(resp.Body)
 		_ = resp.Body.Close()
 		if err != nil {
 			t.Fatalf("read resp error %v", err)


### PR DESCRIPTION
The io/ioutil package has been deprecated as of Go 1.16, see
https://golang.org/doc/go1.16#ioutil. This commit replaces the existing
io/ioutil functions with their new definitions in io and os packages.

Signed-off-by: Eng Zer Jun <engzerjun@gmail.com>

<!--
🎉 Thanks for sending a pull request to Kratos! Here are some tips for you:

1. If this is your first time contributing to Kratos, please read our contribution guide: https://go-kratos.dev/en/docs/community/contribution/
2. Ensure you have added or ran the appropriate tests and lint for your PR, please use `make lint` and `make test` before filing your PR, use `make clean` to tidy your go mod.
3. If the PR is unfinished, you may need mark it as a WIP(Work In Progress) PR or draft PR
4. Please use a conventional commits format title: `<type>[optional scope]: <description>`
    
    Some suggestion on <type>:

    fix: A bug fix
    feat: A new feature
    test: Adding missing tests or correcting existing tests
    refactor: A code change that neither fixes a bug nor adds a feature
    break: Changes has break change

    docs: Documentation only changes
    deps: Changes external dependencies
    style: Changes that do not affect the meaning of the code (white-space, formatting, etc)
    chore Daily work, examples, etc.
    ci: Changes to our CI configuration files and scripts
-->

#### Description (what this PR does / why we need it):
<!--
* The description should include the motivation for this PR or contrast this with previous behavior
-->


#### Which issue(s) this PR fixes (resolves / be part of):
<!--
* Automatically closes linked issue when PR is merged.
* If you PR is not fully resolved issue, please use `part of #<issue number>` instead.

Usage: `fixes/resolves #<issue number>`, or `fixes/resolves (paste link of issue)`.
-->
fixes #

#### Other special notes for reviewer:
<!--
* Somethings that need extra attention for reviewer
* Some additional notes, TODO list, etc.
-->
